### PR TITLE
Fix FliptProvider return type and improve its type declarations

### DIFF
--- a/packages/flipt-react/src/context/FliptProvider.tsx
+++ b/packages/flipt-react/src/context/FliptProvider.tsx
@@ -1,22 +1,19 @@
-import React, { useMemo } from 'react';
+import React, { createContext, ReactElement, ReactNode, useMemo } from 'react';
 import { createFliptSDK, FlipSDKInstance } from '@betrybe/flipt-sdk';
-import { createContext, ReactNode } from 'react';
 
-type FliptProviderProps = {
+export type FliptContextValue = {
   flipt: FlipSDKInstance;
   uri: string;
-  children: ReactNode;
 };
 
-export const FliptContext = createContext<Omit<
-  FliptProviderProps,
-  'children'
-> | null>(null);
+export type FliptProviderProps = {
+  children: ReactNode;
+  uri: string;
+};
 
-function FliptProvider({
-  children,
-  uri,
-}: Omit<FliptProviderProps, 'flipt'>): ReactNode {
+export const FliptContext = createContext<FliptContextValue | null>(null);
+
+function FliptProvider({ children, uri }: FliptProviderProps): ReactElement {
   const flipt = useMemo(() => createFliptSDK({ uri }), [uri]);
 
   const value = useMemo(


### PR DESCRIPTION
I've fixed `FliptProvider` return types, it should be `ReactElement` instead of `ReactNode`.

![image](https://user-images.githubusercontent.com/9027363/140079736-4318839d-0c06-44a4-99a8-37f7e7a267e7.png)


I've also split `FliptProviderProps` into two types. `FliptProvider` and `FliptContext` were sharing it, but they really only share `url` attribute and it doesn't worth all that `Omit` logic.